### PR TITLE
Add support for auth string in proxy URL.

### DIFF
--- a/src/proxy-bio.c
+++ b/src/proxy-bio.c
@@ -30,12 +30,18 @@
 #include <netdb.h>
 
 #include <stdint.h>
+#include <string.h>
 
 #ifndef HAVE_STRNLEN
 #include "src/common/strnlen.h"
 #endif
 
 #include "src/proxy-bio.h"
+
+const char* BASE64_ENCODE_LUT
+  = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+const char BASE64_ENCODE_PAD = '=';
+const char* PROXY_AUTH_HEADER_START = "Proxy-Authorization: Basic ";
 
 int socks4a_connect (BIO *b);
 int socks5_connect (BIO *b);
@@ -48,6 +54,7 @@ int proxy_new (BIO *b)
     return 0;
   ctx->connected = 0;
   ctx->connect = NULL;
+  ctx->auth = NULL;
   ctx->host = NULL;
   ctx->port = 0;
   b->init = 1;
@@ -62,6 +69,8 @@ int proxy_free (BIO *b)
   if (!b || !b->ptr)
     return 1;
   c = (struct proxy_ctx *) b->ptr;
+  if (c->auth)
+    free (c->auth);
   if (c->host)
     free (c->host);
   c->host = NULL;
@@ -251,6 +260,8 @@ int http_connect (BIO *b)
   struct proxy_ctx *ctx = (struct proxy_ctx *) b->ptr;
   char buf[4096];
   int retcode;
+  char *c;
+  char encode_buf[3];
   snprintf (buf, sizeof (buf), "CONNECT %s:%d HTTP/1.1\r\n",
             ctx->host, ctx->port);
   r = BIO_write (b->next_bio, buf, strlen (buf));
@@ -265,6 +276,45 @@ int http_connect (BIO *b)
     return -1;
   if ( (size_t) r != strlen(buf))
     return 0;
+
+  /* write proxy auth header, if applicable */
+  if (ctx->auth) {
+	  c = ctx->auth;
+	  r = strlen (PROXY_AUTH_HEADER_START);
+
+	  /* make sure this header will fit in the buffer. */
+	  /* base64-encoded size is 4/3 original size. */
+	  int div_tmp = strlen(c) * 4; /* hacky way to get ceil(size*4/3) without -lmath. */
+	  if ( !(sizeof (buf) >= r + (div_tmp/3 + (div_tmp % 3 != 0)) + 2)) {
+		  /* buffer too small to accomadate header */
+		  return -1;
+	  }
+
+	  strcpy (buf, PROXY_AUTH_HEADER_START);
+
+	  /* base64-encode and write auth string */
+	  while (*c) {
+		  encode_buf[0] = *c++;
+		  encode_buf[1] = encode_buf[0] ? *c : 0;
+		  encode_buf[2] = encode_buf[1] ? *++c : 0;
+		  if (encode_buf[2])
+			  c++;
+
+		  buf[r++] = BASE64_ENCODE_LUT[(encode_buf[0] & 0b11111100) >> 2];
+		  buf[r++] = BASE64_ENCODE_LUT[((encode_buf[0] & 0b00000011) << 4) | ((encode_buf[1] & 0b11110000) >> 4)];
+		  buf[r++] = encode_buf[1] ? BASE64_ENCODE_LUT[((encode_buf[1] & 0b00001111) << 2) | ((encode_buf[2] & 0b11000000) >> 6)] : BASE64_ENCODE_PAD;
+		  buf[r++] = encode_buf[2] ? BASE64_ENCODE_LUT[(encode_buf[2] & 0b00111111)] : BASE64_ENCODE_PAD;
+	  }
+
+	  strcpy (buf + r, "\r\n");
+
+	  r = BIO_write (b->next_bio, buf, strlen (buf));
+	  if ( -1 == r )
+		  return -1;
+	  if ( (size_t) r != strlen(buf))
+		  return 0;
+  }
+
   strcpy (buf, "\r\n");
   r = BIO_write (b->next_bio, buf, strlen (buf));
   if ( -1 == r )
@@ -411,6 +461,15 @@ int API BIO_proxy_set_type (BIO *b, const char *type)
     ctx->connect = http_connect;
   else
     return 1;
+  return 0;
+}
+
+int API BIO_proxy_set_auth (BIO *b, const char *auth)
+{
+  struct proxy_ctx *ctx = (struct proxy_ctx *) b->ptr;
+  if (strlen(auth)) {
+	  ctx->auth = strdup (auth);
+  }
   return 0;
 }
 

--- a/src/proxy-bio.h
+++ b/src/proxy-bio.h
@@ -16,6 +16,7 @@
 #include "util.h"
 
 struct proxy_ctx {
+  char *auth;
   char *host;
   uint16_t port;
   int connected;
@@ -26,6 +27,7 @@ BIO *BIO_new_proxy();
 
 /* These do not take ownership of their string arguments. */
 int BIO_proxy_set_type (BIO *b, const char *type);
+int BIO_proxy_set_auth (BIO *b, const char *auth);
 int BIO_proxy_set_host (BIO *b, const char *host);
 void BIO_proxy_set_port (BIO *b, uint16_t port);
 

--- a/src/tlsdate.h
+++ b/src/tlsdate.h
@@ -136,9 +136,10 @@ struct opts
 };
 
 #define MAX_FQDN_LEN 255
+#define MAX_AUTH_LEN 1024 /* TW NOTE: I chose this arbitrarily. */
 #define MAX_SCHEME_LEN 9
 #define MAX_PORT_LEN 6  /* incl. : */
-#define MAX_PROXY_URL (MAX_FQDN_LEN + MAX_SCHEME_LEN + MAX_PORT_LEN + 1)
+#define MAX_PROXY_URL (MAX_SCHEME_LEN + MAX_AUTH_LEN + MAX_FQDN_LEN + MAX_PORT_LEN + 1)
 
 enum event_id_t
 {


### PR DESCRIPTION
tlsdate is a timesync utility that obtains the current time via a TLS handshake. It has built in support for proxy servers, but no support for proxy URLs that contain auth strings. This PR adds that support. Note that this is only implemented in the way that we would use this app, which is to say, built with openssl (rather than polarssl), and specified as a CLA (rather than from the config file). This is because this is a temporary stopgap until we have devices with RTC, and thus is, to some extent, throwaway work.

Though this package seems to provide a systemd unit, it wasn't installed automatically when I built this on device, and ours will need to be quite different. As such, I didn't mess with that, and figure that this can be set up in the forthcoming bitbake recipe.

TEST PLAN

- To get this to build, you'll need to install `libevent` and `libevent-dev`.
  - `scp bitbake@100.24.31.209:/debs/meta:master-tulip:master/cortexa8hf-neon/libevent_2.1.8-r0_armhf.deb .`.
  - `scp bitbake@100.24.31.209:/debs/meta:master-tulip:master/cortexa8hf-neon/libevent-dev_2.1.8-r0_armhf.deb .`.
  - Copy these to the gateway and do `dpkg -i libevent_2.1.8-r0_armhf.deb` and `dpkg -i libevent-dev_2.1.8-r0_armhf.deb`.
- Pull this repo on device.
- Set your working directory to the root of the repo.
- `./autogen.sh`
- `./configure`
- `make`
- `make install`

Note that this will install tlsdate to `/usr/local/bin`, which is not in the path.

- Run `/usr/local/bin/tlsdate --verbose` (you may need to be root). You should see output like:
```
V: tlsdate version 0.0.13
V: We were called with the following arguments:
V: validate SSL certificates host = google.com:443
V: RECENT_COMPILE_DATE is 1549291241.000000
V: we'll do the time warp another time - we're not setting clock
V: time is currently 1549301515.436991719
V: time is greater than RECENT_COMPILE_DATE
V: using TLSv1_client_method()
V: Using OpenSSL for SSL
V: opening socket to google.com:443
V: In TLS response, T=1549301516
V: certificate verification passed
V: commonName mismatch! Expected: google.com - received: *.google.com
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: Forced match of 'google' against '*'
V: subjectAltName matched: google.com, type: DNS
V: hostname verification passed
V: key type: EVP_PKEY_RSA
V: keybits: 2048
V: server time 1549301516 (difference is about -1 s) was fetched in 883 ms
V: setting time succeeded
```

- To confirm that this works with auth proxy, run `/usr/local/bin/tlsdate -x http://tulip:tulip@10.0.0.117:3129 --verbose`.
- Now run that again, with the auth wrong, to confirm it doesn't work (i.e., you aren't somehow circumventing the proxy): `/usr/local/bin/tlsdate -x http://tulip:tp@10.0.0.117:3129 --verbose`.
- Now run it with a no-auth proxy and confirm it works: `/usr/local/bin/tlsdate -x http://10.0.0.117:3131 --verbose`.